### PR TITLE
CORE-11995 Remove identifier hash from `FungibleState`

### DIFF
--- a/fungible/src/main/java/com/r3/corda/ledger/utxo/fungible/FungibleState.java
+++ b/fungible/src/main/java/com/r3/corda/ledger/utxo/fungible/FungibleState.java
@@ -22,10 +22,11 @@ public interface FungibleState<T extends Numeric<?>> extends ContractState {
     T getQuantity();
 
     /**
-     * Gets the unique identifier {@link SecureHash} of the current {@link FungibleState}.
+     * Determines whether the current {@link FungibleState} is fungible with the specified other {@link FungibleState}.
+     * The default implementation only considers {@link FungibleState} instances of the same type to be fungible.
      *
-     * @return Returns the unique identifier {@link SecureHash} of the current {@link FungibleState}.
+     * @param other The other {@link FungibleState} to determine is fungible with the current {@link FungibleState}.
+     * @return Returns true if the current {@link FungibleState} is fungible with the specified other {@link FungibleState}; otherwise, false.
      */
-    @NotNull
-    SecureHash getIdentifierHash();
+    boolean isFungibleWith(@NotNull FungibleState<T> other);
 }

--- a/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/ExampleFungibleStateA.kt
+++ b/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/ExampleFungibleStateA.kt
@@ -1,6 +1,5 @@
 package com.r3.corda.ledger.utxo.fungible
 
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.BelongsToContract
 import java.security.PublicKey
 
@@ -8,8 +7,7 @@ import java.security.PublicKey
 data class ExampleFungibleStateA(
     val alice: PublicKey,
     val bob: PublicKey,
-    private val quantity: NumericDecimal,
-    private val identifierHash: SecureHash = SecureHash.parse("SHA256:000000000000000000000000000000000000000000000000000000000000000A")
+    private val quantity: NumericDecimal
 ) : FungibleState<NumericDecimal> {
 
     override fun getParticipants(): List<PublicKey> {
@@ -20,7 +18,7 @@ data class ExampleFungibleStateA(
         return quantity
     }
 
-    override fun getIdentifierHash(): SecureHash {
-        return identifierHash
+    override fun isFungibleWith(other: FungibleState<NumericDecimal>): Boolean {
+        return javaClass == other.javaClass
     }
 }

--- a/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/ExampleFungibleStateB.kt
+++ b/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/ExampleFungibleStateB.kt
@@ -1,6 +1,5 @@
 package com.r3.corda.ledger.utxo.fungible
 
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.BelongsToContract
 import java.security.PublicKey
 
@@ -8,8 +7,7 @@ import java.security.PublicKey
 data class ExampleFungibleStateB(
     val alice: PublicKey,
     val bob: PublicKey,
-    private val quantity: NumericDecimal,
-    private val identifierHash: SecureHash = SecureHash.parse("SHA256:000000000000000000000000000000000000000000000000000000000000000A")
+    private val quantity: NumericDecimal
 ) : FungibleState<NumericDecimal> {
 
     override fun getParticipants(): List<PublicKey> {
@@ -20,7 +18,7 @@ data class ExampleFungibleStateB(
         return quantity
     }
 
-    override fun getIdentifierHash(): SecureHash {
-        return identifierHash
+    override fun isFungibleWith(other: FungibleState<NumericDecimal>): Boolean {
+        return javaClass == other.javaClass
     }
 }


### PR DESCRIPTION
Removed the identifier hash from `FungibleState`. The contract now checks fungibility using an `isFungibleWith` function.