### PR TITLE
CORE-12031 : Refactor IdentifiableState to extend ContractState instead of VisibleState

### DIFF
--- a/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiableState.java
+++ b/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiableState.java
@@ -1,6 +1,5 @@
 package com.r3.corda.ledger.utxo.identifiable;
 
-import com.r3.corda.ledger.utxo.base.VisibleState;
 import net.corda.v5.ledger.utxo.BelongsToContract;
 import net.corda.v5.ledger.utxo.ContractState;
 import net.corda.v5.ledger.utxo.StateRef;
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * Defines a mechanism for implementing uniquely identifiable states.
  */
 @BelongsToContract(IdentifiableContract.class)
-public interface IdentifiableState extends VisibleState {
+public interface IdentifiableState extends ContractState {
 
     /**
      * Gets the unique ID of the current {@link IdentifiableState}, or null if it's the first state.


### PR DESCRIPTION
Refactored `IdentifiableState` to extend `ContractState` instead of `VisibleState`, as this should be an opt-in for CorDapp developers.