### PR TITLE
CORE-13156 : BUGFIX - Prevent zero-value outputs on deletion of fungible states.

### DIFF
--- a/fungible/src/main/java/com/r3/corda/ledger/utxo/fungible/FungibleConstraints.java
+++ b/fungible/src/main/java/com/r3/corda/ledger/utxo/fungible/FungibleConstraints.java
@@ -38,6 +38,9 @@ public final class FungibleConstraints {
     final static String CONTRACT_RULE_DELETE_INPUTS =
             "On fungible state(s) deleting, at least one fungible state input must be consumed.";
 
+    final static String CONTRACT_RULE_DELETE_POSITIVE_QUANTITIES =
+            "On fungible state(s) deleting, the quantity of every created fungible state must be greater than zero.";
+
     final static String CONTRACT_RULE_DELETE_SUM =
             "On fungible state(s) deleting, the sum of the unscaled values of the consumed states must be greater than the sum of the unscaled values of the created states.";
 
@@ -170,6 +173,7 @@ public final class FungibleConstraints {
         final List<T> outputs = transaction.getOutputStates(type);
 
         Check.isNotEmpty(inputs, CONTRACT_RULE_DELETE_INPUTS);
+        Check.all(outputs, it -> it.getQuantity().getUnscaledValue().compareTo(BigInteger.ZERO) > 0, CONTRACT_RULE_DELETE_POSITIVE_QUANTITIES);
         Check.isGreaterThan(FungibleUtils.sum(inputs), FungibleUtils.sum(outputs), CONTRACT_RULE_DELETE_SUM);
 
         // We have to check all inputs and outputs, because we might create an extra output for which there is no input.

--- a/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/FungibleContractDeleteCommandTests.kt
+++ b/fungible/src/test/kotlin/com/r3/corda/ledger/utxo/fungible/FungibleContractDeleteCommandTests.kt
@@ -62,6 +62,23 @@ class FungibleContractDeleteCommandTests : ContractTest() {
     }
 
     @Test
+    fun `On fungible state(s) deleting, the quantity of every created fungible state must be greater than zero`() {
+
+        // Arrange
+        val transaction = buildTransaction(NOTARY_KEY, NOTARY_NAME) {
+            addInputState(stateA)
+            addOutputState(stateA.copy(quantity = NumericDecimal.ZERO))
+            addCommand(ExampleFungibleContract.Delete())
+        }
+
+        // Act
+        val exception = assertThrows<IllegalStateException> { contract.verify(transaction) }
+
+        // Assert
+        assertEquals(FungibleConstraints.CONTRACT_RULE_DELETE_POSITIVE_QUANTITIES, exception.message)
+    }
+
+    @Test
     fun `On fungible state(s) deleting, the sum of the absolute values of the consumed states must be greater than the sum of the absolute values of the created states (quantity is equal)`() {
 
         // Arrange


### PR DESCRIPTION
Fixed bug to prevent zero-value outputs on deletion of fungible states.