### PR TITLE
ES-558: correct versions in JenkinsfileE2E

### DIFF
--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -1,9 +1,9 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
-    helmVersion: '^5.1.0-beta',
+    helmVersion: '^5.0.0-beta',
     dynamicCordaApiVersion: false
 )


### PR DESCRIPTION
- use the correct helm chart in e2e tests, take the latest 5.0.0 version from release branch 