### PR TITLE
ES-356: Update CODEOWNERS file for Freeze

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-Jenkinsfile        @corda/blt
-.ci/*              @corda/blt
-.github/*          @corda/blt
+# Reduced list for the duration of 5.0 code freeze 
+* @mnesbit @driessamyn @ronanbrowne @rick-r3 @fenryka @yarivus 


### PR DESCRIPTION
Update code owners file pre-freeze - these owners should get approval from product owners pre any merging.

This has been discussed already with team leads and applied to other corda5 projects 