### PR TITLE
ES-763: ensure publishToMavenS3Repository is true

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,6 @@ cordaPipelineKubernetesAgent(
     dedicatedJobForSnykDelta: false,
     gitHubComments: false,
     e2eTestName: 'corda-utxo-ledger-extensions-e2e-tests',
-    runE2eTests: true // to be actived once tests are implemented in this repo
+    runE2eTests: true,
+    publishToMavenS3Repository: true
     )


### PR DESCRIPTION
`publishToMavenS3Repository` Jenkins property should be set to true to ensure all needed properties are published externally.

- we use an s3 location as an internal staging area before final publishing to Maven Staging / Central 

No functional application change 