### PR TITLE
CORE-18750 Handle stable vault-named query changes

### DIFF
--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -1,11 +1,9 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
-    helmRepoSuffix: 'release/os/5.1',
-    helmVersion: '^5.1.0-beta',
     dynamicCordaApiVersion: false,
     gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
     javaVersion: '17'

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -5,6 +5,6 @@ endToEndPipeline(
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
     dynamicCordaApiVersion: false,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.1.0.0-beta+',
     javaVersion: '17'
 )

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -6,5 +6,6 @@ endToEndPipeline(
     usePackagedCordaHelmChart: true,
     helmVersion: '^5.0.0-beta',
     dynamicCordaApiVersion: false,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+'
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
+    javaVersion: '17'
 )

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -4,7 +4,7 @@ endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
-    helmVersion: '^5.0.0-beta',
+    helmVersion: '^5.1.0-beta',
     dynamicCordaApiVersion: false,
     gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
     javaVersion: '17'

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -4,6 +4,7 @@ endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
+    helmRepoSuffix: 'release/os/5.1',
     helmVersion: '^5.1.0-beta',
     dynamicCordaApiVersion: false,
     gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     publishRepoPrefix: 'corda-os-maven',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,6 @@ cordaPipelineKubernetesAgent(
     e2eTestName: 'corda-utxo-ledger-extensions-e2e-tests',
     runE2eTests: true,
     publishToMavenS3Repository: true,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+'
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
+    javaVersion: '17'
     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,6 @@ cordaPipelineKubernetesAgent(
     e2eTestName: 'corda-utxo-ledger-extensions-e2e-tests',
     runE2eTests: true,
     publishToMavenS3Repository: true,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.0.0.0-beta+',
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.1.0.0-beta+',
     javaVersion: '17'
     )

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
-import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 
 plugins {
@@ -9,7 +9,7 @@ plugins {
     id 'corda.root-publish'
 }
 
-def javaVersion = 11
+def javaVersion = 17
 
 allprojects {
     // CORE-17624: We need these notary dependencies at the same version to pass validation checks when building the CPI
@@ -68,7 +68,7 @@ subprojects {
                 allWarningsAsErrors = true
                 languageVersion = KOTLIN_1_8
                 apiVersion = KOTLIN_1_8
-                jvmTarget = JVM_11
+                jvmTarget = JVM_17
                 javaParameters = true   // Useful for reflection.
                 freeCompilerArgs.addAll([
                     "-Xjvm-default=all"

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,17 @@ plugins {
 
 def javaVersion = 11
 
+allprojects {
+    // CORE-17624: We need these notary dependencies at the same version to pass validation checks when building the CPI
+    pluginManager.withPlugin('net.corda.plugins.cordapp-cpb2') {
+        dependencies {
+            cordapp "com.r3.corda.notary.plugin.common:notary-plugin-common:$cordaNotaryPluginsVersion"
+            cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-api:$cordaNotaryPluginsVersion"
+            cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
+        }
+    }
+}
+
 subprojects {
     group 'com.r3.corda.ledger.utxo'
     if (System.getenv("RELEASE_VERSION")?.trim()) {
@@ -119,6 +130,10 @@ subprojects {
                     includeGroup 'antlr'
                 }
             }
+        }
+
+        maven {
+            url = "https://download.corda.net/maven/corda-dependencies"
         }
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@ def internalPublishVersion = constants.getProperty('internalPublishVersion')
 def artifactoryContextUrl = constants.getProperty('artifactoryContextUrl')
 
 repositories {
+        mavenLocal()
         def cordaUseCache = System.getenv("CORDA_USE_CACHE")
         if (cordaUseCache != null) {
             maven {

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -82,6 +82,7 @@ dependencies {
 
     e2eTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     e2eTestRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    e2eTestRuntimeOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
 }
 
 def e2eTestResources = tasks.named('processE2eTestResources', ProcessResources) {

--- a/e2e-tests/cpbs/ledger-utxo-advanced-chainable-test-app/build.gradle
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-chainable-test-app/build.gradle
@@ -19,7 +19,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':e2e-tests:cpbs:ledger-utxo-advanced-chainable-test-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-fungible-test-app/build.gradle
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-fungible-test-app/build.gradle
@@ -21,7 +21,4 @@ dependencies {
     cordapp project(":fungible")
 
     cordapp project(':e2e-tests:cpbs:ledger-utxo-advanced-fungible-test-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-identifiable-test-app/build.gradle
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-identifiable-test-app/build.gradle
@@ -19,7 +19,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':e2e-tests:cpbs:ledger-utxo-advanced-identifiable-test-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-identifiable-test-app/src/main/kotlin/com/r3/corda/test/utxo/identifiable/workflow/IdentifiableStateQueryFlow.kt
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-identifiable-test-app/src/main/kotlin/com/r3/corda/test/utxo/identifiable/workflow/IdentifiableStateQueryFlow.kt
@@ -95,17 +95,14 @@ class IdentifiableStateQueryFlow : ClientStartableFlow {
     private fun executeQuery(
         query: VaultNamedParameterizedQuery<StateAndRef<TestIdentifiableState>>
     ): List<StateAndRef<TestIdentifiableState>> {
-        var offset = 0
         query.apply {
-            setOffset(offset)
             setCreatedTimestampLimit(Instant.now())
         }
         val results = mutableListOf<StateAndRef<TestIdentifiableState>>()
-        var resultSet = query.execute()
-        while (resultSet.results.isNotEmpty()) {
-            results += resultSet.results
-            offset += 50
-            resultSet = query.setOffset(offset).execute()
+        val resultSet = query.execute()
+        results += resultSet.results
+        while (resultSet.hasNext()) {
+            results += resultSet.next()
         }
         return results
     }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/build.gradle
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/build.gradle
@@ -18,7 +18,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':e2e-tests:cpbs:ledger-utxo-advanced-issuable-test-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/src/main/kotlin/com/r3/corda/test/utxo/issuable/workflow/IssuableStateQueryFlow.kt
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/src/main/kotlin/com/r3/corda/test/utxo/issuable/workflow/IssuableStateQueryFlow.kt
@@ -102,18 +102,14 @@ class IssuableStateQueryFlow : ClientStartableFlow {
     private fun executeQuery(
         query: VaultNamedParameterizedQuery<StateAndRef<TestIssuableState>>
     ): List<StateAndRef<TestIssuableState>> {
-        var offset = 0
         query.apply {
-            setOffset(offset)
             setCreatedTimestampLimit(Instant.now())
         }
         val results = mutableListOf<StateAndRef<TestIssuableState>>()
-        var resultSet = query.execute()
-        while (resultSet.results.isNotEmpty()) {
-            results += resultSet.results
-            offset += 50
-            query.setOffset(offset)
-            resultSet = query.execute()
+        val resultSet = query.execute()
+        results += resultSet.results
+        while (resultSet.hasNext()) {
+            results += resultSet.next()
         }
         return results
     }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/src/main/kotlin/com/r3/corda/test/utxo/issuable/workflow/WellKnownIssuableStateQueryFlow.kt
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-issuable-test-app/src/main/kotlin/com/r3/corda/test/utxo/issuable/workflow/WellKnownIssuableStateQueryFlow.kt
@@ -96,18 +96,14 @@ class WellKnownIssuableStateQueryFlow : ClientStartableFlow {
     private fun executeQuery(
         query: VaultNamedParameterizedQuery<StateAndRef<TestIssuableState>>
     ): List<StateAndRef<TestIssuableState>> {
-        var offset = 0
         query.apply {
-            setOffset(offset)
             setCreatedTimestampLimit(Instant.now())
         }
         val results = mutableListOf<StateAndRef<TestIssuableState>>()
-        var resultSet = query.execute()
-        while (resultSet.results.isNotEmpty()) {
-            results += resultSet.results
-            offset += 50
-            query.setOffset(offset)
-            resultSet = query.execute()
+        val resultSet = query.execute()
+        results += resultSet.results
+        while (resultSet.hasNext()) {
+            results += resultSet.next()
         }
         return results
     }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/build.gradle
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/build.gradle
@@ -18,7 +18,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':e2e-tests:cpbs:ledger-utxo-advanced-ownable-test-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/src/main/kotlin/com/r3/corda/test/utxo/ownable/workflow/OwnableStateQueryFlow.kt
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/src/main/kotlin/com/r3/corda/test/utxo/ownable/workflow/OwnableStateQueryFlow.kt
@@ -102,18 +102,14 @@ class OwnableStateQueryFlow : ClientStartableFlow {
     private fun executeQuery(
         query: VaultNamedParameterizedQuery<StateAndRef<TestOwnableState>>
     ): List<StateAndRef<TestOwnableState>> {
-        var offset = 0
         query.apply {
-            setOffset(offset)
             setCreatedTimestampLimit(Instant.now())
         }
         val results = mutableListOf<StateAndRef<TestOwnableState>>()
-        var resultSet = query.execute()
-        while (resultSet.results.isNotEmpty()) {
-            results += resultSet.results
-            offset += 50
-            query.setOffset(offset)
-            resultSet = query.execute()
+        val resultSet = query.execute()
+        results += resultSet.results
+        while (resultSet.hasNext()) {
+            results += resultSet.next()
         }
         return results
     }

--- a/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/src/main/kotlin/com/r3/corda/test/utxo/ownable/workflow/WellKnownOwnableStateQueryFlow.kt
+++ b/e2e-tests/cpbs/ledger-utxo-advanced-ownable-test-app/src/main/kotlin/com/r3/corda/test/utxo/ownable/workflow/WellKnownOwnableStateQueryFlow.kt
@@ -96,18 +96,14 @@ class WellKnownOwnableStateQueryFlow : ClientStartableFlow {
     private fun executeQuery(
         query: VaultNamedParameterizedQuery<StateAndRef<TestOwnableState>>
     ): List<StateAndRef<TestOwnableState>> {
-        var offset = 0
         query.apply {
-            setOffset(offset)
             setCreatedTimestampLimit(Instant.now())
         }
         val results = mutableListOf<StateAndRef<TestOwnableState>>()
-        var resultSet = query.execute()
-        while (resultSet.results.isNotEmpty()) {
-            results += resultSet.results
-            offset += 50
-            query.setOffset(offset)
-            resultSet = query.execute()
+        val resultSet = query.execute()
+        results += resultSet.results
+        while (resultSet.hasNext()) {
+            results += resultSet.next()
         }
         return results
     }

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/ChainableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/ChainableTests.kt
@@ -26,6 +26,7 @@ class ChainableTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-chainable-test-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-chainable-test-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -73,7 +74,7 @@ class ChainableTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/FungibleTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/FungibleTests.kt
@@ -18,6 +18,7 @@ class FungibleTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-fungible-test-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-fungible-test-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -69,7 +70,7 @@ class FungibleTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IdentifiableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IdentifiableTests.kt
@@ -27,6 +27,7 @@ class IdentifiableTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-identifiable-test-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-identifiable-test-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -68,7 +69,7 @@ class IdentifiableTests {
 
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IssuableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IssuableTests.kt
@@ -26,6 +26,7 @@ class IssuableTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-issuable-test-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-issuable-test-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -67,7 +68,7 @@ class IssuableTests {
 
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/OwnableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/OwnableTests.kt
@@ -26,6 +26,7 @@ class OwnableTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-ownable-test-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-ownable-test-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -67,7 +68,7 @@ class OwnableTests {
 
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
@@ -91,7 +91,7 @@ class ChainableDemoTests {
                 "id" to vehicleId,
                 "manufacturer" to aliceX500,
                 "owner" to bobX500,
-                "notary" to notaryX500,
+                "notary" to NOTARY_SERVICE_X500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.chainable.workflow.issue.IssueVehicleFlow\$Initiator"

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
@@ -26,6 +26,7 @@ class ChainableDemoTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-chainable-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-chainable-demo-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -73,7 +74,7 @@ class ChainableDemoTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
@@ -91,7 +91,7 @@ class ChainableDemoTests {
                 "id" to vehicleId,
                 "manufacturer" to aliceX500,
                 "owner" to bobX500,
-                "notary" to "O=MyNotaryService-$notaryHoldingId, L=London, C=GB",
+                "notary" to notaryX500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.chainable.workflow.issue.IssueVehicleFlow\$Initiator"

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
@@ -84,7 +84,7 @@ class FungibleDemoTests {
                 "issuer" to aliceX500,
                 "owner" to bobX500,
                 "quantity" to 123.45.toScaledBigDecimal(),
-                "notary" to notaryX500,
+                "notary" to NOTARY_SERVICE_X500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.fungible.workflow.mint.MintTokenFlow\$Initiator"

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
@@ -19,6 +19,7 @@ class FungibleDemoTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-fungible-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-fungible-demo-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -70,7 +71,7 @@ class FungibleDemoTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
@@ -84,7 +84,7 @@ class FungibleDemoTests {
                 "issuer" to aliceX500,
                 "owner" to bobX500,
                 "quantity" to 123.45.toScaledBigDecimal(),
-                "notary" to "O=MyNotaryService-$notaryHoldingId, L=London, C=GB",
+                "notary" to notaryX500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.fungible.workflow.mint.MintTokenFlow\$Initiator"

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
@@ -26,6 +26,7 @@ class IdentifiableDemoTests {
     private companion object {
         const val TEST_CPI_NAME = "corda-ledger-extensions-ledger-utxo-advanced-identifiable-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/corda-ledger-extensions-ledger-utxo-advanced-identifiable-demo-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -67,7 +68,7 @@ class IdentifiableDemoTests {
 
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
@@ -81,7 +81,7 @@ class IdentifiableDemoTests {
                 "description" to "Build super-duper DLT and call it Corda 5",
                 "reporter" to aliceX500,
                 "assignee" to bobX500,
-                "notary" to "O=MyNotaryService-$notaryHoldingId, L=London, C=GB",
+                "notary" to notaryX500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.identifiable.workflow.create.CreateSupportTicketFlow\$Initiator"

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
@@ -81,7 +81,7 @@ class IdentifiableDemoTests {
                 "description" to "Build super-duper DLT and call it Corda 5",
                 "reporter" to aliceX500,
                 "assignee" to bobX500,
-                "notary" to notaryX500,
+                "notary" to NOTARY_SERVICE_X500,
                 "observers" to emptyList<String>()
             ),
             "com.r3.corda.demo.utxo.identifiable.workflow.create.CreateSupportTicketFlow\$Initiator"

--- a/examples/ledger-utxo-advanced-chainable-demo-app/build.gradle
+++ b/examples/ledger-utxo-advanced-chainable-demo-app/build.gradle
@@ -19,7 +19,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':examples:ledger-utxo-advanced-chainable-demo-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/examples/ledger-utxo-advanced-chainable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/chainable/workflow/transfer/TransferVehicleRequest.kt
+++ b/examples/ledger-utxo-advanced-chainable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/chainable/workflow/transfer/TransferVehicleRequest.kt
@@ -11,6 +11,7 @@ import com.r3.corda.demo.utxo.chainable.contract.Vehicle
 import com.r3.corda.demo.utxo.chainable.contract.transferOwnership
 import com.r3.corda.demo.utxo.chainable.workflow.firstLedgerKey
 import com.r3.corda.demo.utxo.chainable.workflow.getMemberInfo
+import java.time.Instant
 import java.util.UUID
 
 data class TransferVehicleRequest(
@@ -22,7 +23,8 @@ data class TransferVehicleRequest(
     @Suspendable
     fun getInputState(utxoLedgerService: UtxoLedgerService): StateAndRef<Vehicle> {
         return utxoLedgerService
-            .findUnconsumedStatesByType(Vehicle::class.java)
+            .findUnconsumedStatesByExactType(Vehicle::class.java, 1, Instant.now())
+            .results
             .single { it.state.contractState.id == id }
     }
 

--- a/examples/ledger-utxo-advanced-fungible-demo-app/build.gradle
+++ b/examples/ledger-utxo-advanced-fungible-demo-app/build.gradle
@@ -21,7 +21,4 @@ dependencies {
     cordapp project(":fungible")
 
     cordapp project(':examples:ledger-utxo-advanced-fungible-demo-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/examples/ledger-utxo-advanced-fungible-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/fungible/workflow/UtxoLedgerServiceExtensions.kt
+++ b/examples/ledger-utxo-advanced-fungible-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/fungible/workflow/UtxoLedgerServiceExtensions.kt
@@ -21,7 +21,6 @@ internal fun UtxoLedgerService.getAvailableTokens(
     return query(OwnableStateQueries.GET_BY_OWNER, StateAndRef::class.java)
         .setCreatedTimestampLimit(Instant.now())
         .setLimit(50)
-        .setOffset(0)
         .setParameter("owner", digestService.hash(ownerKeys.single().encoded, DigestAlgorithmName.SHA2_256).toString())
         .setParameter("stateType", Token::class.java.name)
         .execute()

--- a/examples/ledger-utxo-advanced-identifiable-demo-app/build.gradle
+++ b/examples/ledger-utxo-advanced-identifiable-demo-app/build.gradle
@@ -19,7 +19,4 @@ dependencies {
     cordaProvided 'net.corda:corda-ledger-utxo'
 
     cordapp project(':examples:ledger-utxo-advanced-identifiable-demo-contract')
-
-    // Common and API packages pulled in as transitive dependencies through client
-    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
 }

--- a/examples/ledger-utxo-advanced-identifiable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/identifiable/workflow/delete/DeleteSupportTicketRequest.kt
+++ b/examples/ledger-utxo-advanced-identifiable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/identifiable/workflow/delete/DeleteSupportTicketRequest.kt
@@ -15,8 +15,8 @@ data class DeleteSupportTicketRequest(val id: String, val assignee: String, val 
     @Suspendable
     fun getInputState(utxoLedgerService: UtxoLedgerService): StateAndRef<SupportTicket> {
         return utxoLedgerService.query(IdentifiableStateQueries.GET_BY_IDS, StateAndRef::class.java)
-            .setCreatedTimestampLimit(Instant.now()).setLimit(50)
-            .setOffset(0)
+            .setCreatedTimestampLimit(Instant.now())
+            .setLimit(50)
             .setParameter("ids", listOf(id))
             .execute()
             .results

--- a/examples/ledger-utxo-advanced-identifiable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/identifiable/workflow/update/UpdateSupportTicketRequest.kt
+++ b/examples/ledger-utxo-advanced-identifiable-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/identifiable/workflow/update/UpdateSupportTicketRequest.kt
@@ -21,8 +21,8 @@ data class UpdateSupportTicketRequest(
     @Suspendable
     fun getInputState(utxoLedgerService: UtxoLedgerService): StateAndRef<SupportTicket> {
         return utxoLedgerService.query(IdentifiableStateQueries.GET_BY_IDS, StateAndRef::class.java)
-            .setCreatedTimestampLimit(Instant.now()).setLimit(50)
-            .setOffset(0)
+            .setCreatedTimestampLimit(Instant.now())
+            .setLimit(50)
             .setParameter("ids", listOf(id))
             .execute()
             .results

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,14 +6,14 @@ kotlin.code.style=official
 
 # Specify the version of the Corda-API to use.
 # This needs to match the version supported by the Corda Cluster the CorDapp will run on.
-cordaApiVersion=5.0.0.765
+cordaApiVersion=5.1.0.39
 
 
 # E2e test utilities should come from runtime-os
-cordaRuntimeOsVersion=5.0.0.0
+cordaRuntimeOsVersion=5.1.0.0
 
 # Specify the version of the notary plugins to use, if left blank this will default to value of cordaRuntimeOsVersion
-cordaNotaryPluginsVersion=
+cordaNotaryPluginsVersion=5.0.0.0-beta+
 
 # Specify the version of the cordapp-cpb2 and cordapp-cpk2 plugins
 cordaPluginsVersion=7.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ cordaApiVersion=5.1.0.39
 cordaRuntimeOsVersion=5.1.0.0
 
 # Specify the version of the notary plugins to use, if left blank this will default to value of cordaRuntimeOsVersion
-cordaNotaryPluginsVersion=5.0.0.0-beta+
+cordaNotaryPluginsVersion=5.1.0.0-beta+
 
 # Specify the version of the cordapp-cpb2 and cordapp-cpk2 plugins
 cordaPluginsVersion=7.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,10 @@ cordaApiVersion=5.1.0.39
 
 
 # E2e test utilities should come from runtime-os
-cordaRuntimeOsVersion=5.1.0.0
+cordaRuntimeOsVersion=5.1.0.0-beta+
 
 # Specify the version of the notary plugins to use, if left blank this will default to value of cordaRuntimeOsVersion
-cordaNotaryPluginsVersion=5.1.0.0-beta+
+cordaNotaryPluginsVersion=5.0.0.0-beta+
 
 # Specify the version of the cordapp-cpb2 and cordapp-cpk2 plugins
 cordaPluginsVersion=7.0.3

--- a/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiablePointer.java
+++ b/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiablePointer.java
@@ -93,23 +93,19 @@ public final class IdentifiablePointer<T extends IdentifiableState> implements S
     @Override
     @Suspendable
     public @NotNull List<StateAndRef<T>> resolve(@NotNull UtxoLedgerService service) {
-        List<StateAndRef<T>> resolved = new ArrayList<>();
-        int offset = 0;
 
         @SuppressWarnings("UNCHECKED_CAST")
         PagedQuery<StateAndRef<T>> query = (PagedQuery<StateAndRef<T>>) (PagedQuery<?>) service
                 .query(IdentifiableStateQueries.GET_BY_IDS, StateAndRef.class)
                 .setCreatedTimestampLimit(Instant.now())
                 .setLimit(50)
-                .setOffset(offset)
                 .setParameter("ids", List.of(value.toString()));
 
         PagedQuery.ResultSet<StateAndRef<T>> resultSet = query.execute();
 
-        while (!resultSet.getResults().isEmpty()) {
-            resolved.addAll(resultSet.getResults());
-            offset += 50;
-            resultSet = query.setOffset(offset).execute();
+        List<StateAndRef<T>> resolved = new ArrayList<>(resultSet.getResults());
+        while (resultSet.hasNext()) {
+            resolved.addAll(resultSet.next());
         }
 
         if (resolved.size() > 1) {

--- a/testing/src/main/java/com/r3/corda/ledger/utxo/testing/UtxoLedgerTransactionImpl.java
+++ b/testing/src/main/java/com/r3/corda/ledger/utxo/testing/UtxoLedgerTransactionImpl.java
@@ -3,7 +3,6 @@ package com.r3.corda.ledger.utxo.testing;
 import net.corda.v5.base.types.MemberX500Name;
 import net.corda.v5.crypto.SecureHash;
 import net.corda.v5.ledger.common.transaction.TransactionMetadata;
-import net.corda.v5.ledger.utxo.Attachment;
 import net.corda.v5.ledger.utxo.Command;
 import net.corda.v5.ledger.utxo.ContractState;
 import net.corda.v5.ledger.utxo.StateAndRef;
@@ -11,6 +10,7 @@ import net.corda.v5.ledger.utxo.StateRef;
 import net.corda.v5.ledger.utxo.TimeWindow;
 import net.corda.v5.ledger.utxo.TransactionState;
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction;
+import net.corda.v5.membership.GroupParameters;
 import org.jetbrains.annotations.NotNull;
 
 import java.security.PublicKey;
@@ -29,9 +29,6 @@ final class UtxoLedgerTransactionImpl implements UtxoLedgerTransaction {
 
     @NotNull
     private final MemberX500Name notaryName;
-
-    @NotNull
-    private final List<Attachment> attachments;
 
     @NotNull
     private final List<Command> commands;
@@ -53,7 +50,6 @@ final class UtxoLedgerTransactionImpl implements UtxoLedgerTransaction {
 
     public UtxoLedgerTransactionImpl(@NotNull final UtxoTransactionBuilder builder) {
         this.id = builder.getTransactionId();
-        this.attachments = builder.getAttachments();
         this.commands = builder.getCommands();
         this.signatories = builder.getSignatories();
         this.inputStateAndRefs = builder.getInputStateAndRefs();
@@ -86,12 +82,6 @@ final class UtxoLedgerTransactionImpl implements UtxoLedgerTransaction {
     @Override
     public TransactionMetadata getMetadata() {
         throw new UnsupportedOperationException("TODO : Implement TransactionMetadata");
-    }
-
-    @NotNull
-    @Override
-    public List<Attachment> getAttachments() {
-        return attachments;
     }
 
     @NotNull
@@ -204,25 +194,6 @@ final class UtxoLedgerTransactionImpl implements UtxoLedgerTransaction {
 
     @NotNull
     @Override
-    public Attachment getAttachment(@NotNull final SecureHash id) {
-        List<Attachment> matches = getAttachments()
-                .stream()
-                .filter(attachment -> attachment.getId() == id)
-                .collect(Collectors.toUnmodifiableList());
-
-        if (matches.size() == 0) {
-            throw new IllegalArgumentException("Attachment with the specified ID not found: " + id);
-        }
-
-        if (matches.size() > 1) {
-            throw new IllegalArgumentException("Multiple attachments found with the specified ID: " + id);
-        }
-
-        return matches.get(0);
-    }
-
-    @NotNull
-    @Override
     public <T extends Command> List<T> getCommands(@NotNull final Class<T> type) {
         return getCommands()
                 .stream()
@@ -302,5 +273,11 @@ final class UtxoLedgerTransactionImpl implements UtxoLedgerTransaction {
         }
 
         return Collections.unmodifiableList(result);
+    }
+
+    @NotNull
+    @Override
+    public GroupParameters getGroupParameters() {
+        return null;
     }
 }

--- a/testing/src/main/java/com/r3/corda/ledger/utxo/testing/UtxoTransactionBuilder.java
+++ b/testing/src/main/java/com/r3/corda/ledger/utxo/testing/UtxoTransactionBuilder.java
@@ -2,7 +2,6 @@ package com.r3.corda.ledger.utxo.testing;
 
 import net.corda.v5.base.types.MemberX500Name;
 import net.corda.v5.crypto.SecureHash;
-import net.corda.v5.ledger.utxo.Attachment;
 import net.corda.v5.ledger.utxo.Command;
 import net.corda.v5.ledger.utxo.ContractState;
 import net.corda.v5.ledger.utxo.StateAndRef;
@@ -33,9 +32,6 @@ public final class UtxoTransactionBuilder {
     private final MemberX500Name notaryName;
 
     @NotNull
-    private final List<Attachment> attachments = new ArrayList<>();
-
-    @NotNull
     private final List<Command> commands = new ArrayList<>();
 
     @NotNull
@@ -60,12 +56,6 @@ public final class UtxoTransactionBuilder {
         this.notaryName = notaryName;
         this.transactionId = ContractTestUtils.createRandomSecureHash();
         this.timeWindow = new TimeWindowBetweenImpl(Instant.MIN, Instant.MAX);
-    }
-
-    @NotNull
-    public UtxoTransactionBuilder addAttachment(@NotNull final Attachment attachment) {
-        attachments.add(attachment);
-        return this;
     }
 
     @NotNull
@@ -180,11 +170,6 @@ public final class UtxoTransactionBuilder {
     @NotNull
     public MemberX500Name getNotaryName() {
         return notaryName;
-    }
-
-    @NotNull
-    public List<Attachment> getAttachments() {
-        return attachments;
     }
 
     @NotNull

--- a/testing/src/main/kotlin/com/r3/corda/ledger/utxo/testing/TransactionBuilderDsl.kt
+++ b/testing/src/main/kotlin/com/r3/corda/ledger/utxo/testing/TransactionBuilderDsl.kt
@@ -2,7 +2,6 @@ package com.r3.corda.ledger.utxo.testing
 
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.utxo.Attachment
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
@@ -15,11 +14,6 @@ import java.time.Instant
 class TransactionBuilderDsl(private val notaryKey: PublicKey, private val notaryName: MemberX500Name) {
 
     private val builder = UtxoTransactionBuilder(notaryKey, notaryName)
-
-    @TransactionBuilderDslMarker
-    fun addAttachment(attachment: Attachment): UtxoTransactionBuilder {
-        return builder.addAttachment(attachment)
-    }
 
     @TransactionBuilderDslMarker
     fun addCommand(command: Command): UtxoTransactionBuilder {
@@ -121,11 +115,6 @@ class TransactionBuilderDsl(private val notaryKey: PublicKey, private val notary
     @TransactionBuilderDslMarker
     fun getNotaryName(): MemberX500Name {
         return builder.notaryName
-    }
-
-    @TransactionBuilderDslMarker
-    fun getAttachments(): List<Attachment> {
-        return builder.attachments
     }
 
     @TransactionBuilderDslMarker


### PR DESCRIPTION
Updates in 5.1 broke the usage of `setOffset` as the stable query paging of vault named queries was added.

Changes to some of the ledger extension method and query tests have been updated to handle this change.

Also includes changes to bring the e2e tests more in line with those in the e2e test repo (mainly notary version changes).