### PR TITLE
CORE-13473 Fix bug identifiable state contract constraints allowing multiple outputs with the same ID

### DIFF
--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -1,10 +1,10 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.2') _
 
 endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
     usePackagedCordaHelmChart: true,
     dynamicCordaApiVersion: false,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.1.0.0-beta+',
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.2.0.0-beta+',
     javaVersion: '17'
 )

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -3,7 +3,9 @@
 endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
-    usePackagedCordaHelmChart: false,
+    usePackagedCordaHelmChart: true,
+    helmVersion: '^5.2.0-beta',
+    helmRepoSuffix: 'release/os/5.2',
     dynamicCordaApiVersion: false,
     javaVersion: '17'
 )

--- a/.ci/e2e/JenkinsfileE2E
+++ b/.ci/e2e/JenkinsfileE2E
@@ -3,8 +3,7 @@
 endToEndPipeline(
     multiCluster: false,
     gradleTestTargetsToExecute: ['e2eTest'],
-    usePackagedCordaHelmChart: true,
+    usePackagedCordaHelmChart: false,
     dynamicCordaApiVersion: false,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.2.0.0-beta+',
     javaVersion: '17'
 )

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.2') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5'

--- a/base/src/main/java/com/r3/corda/ledger/utxo/base/Check.java
+++ b/base/src/main/java/com/r3/corda/ledger/utxo/base/Check.java
@@ -8,7 +8,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Provides functionality for contract verification checks.
@@ -209,6 +212,24 @@ public final class Check {
      */
     public static void isNotEmpty(@NotNull final Iterable<?> iterable, @NotNull final String message) {
         isTrue(count(iterable) > 0, message);
+    }
+
+    /**
+     * Checks whether the specified iterable contains distinct elements.
+     *
+     * @param iterable The iterable containing elements to test.
+     * @param message  The message which will be thrown in the event that the iterable does not contain distinct elements.
+     * @throws IllegalStateException if the iterable does not contain distinct elements.
+     */
+    public static void isDistinct(@NotNull final Iterable<?> iterable, @NotNull final String message) {
+        final Set<?> distinctItems = StreamSupport
+                .stream(iterable.spliterator(), false)
+                .collect(Collectors.toSet());
+
+        final int originalCount = count(iterable);
+        final int distinctCount = count(distinctItems);
+
+        isTrue(originalCount == distinctCount, message);
     }
 
     /**

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/ChainableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/ChainableTests.kt
@@ -2,16 +2,16 @@ package com.r3.corda.ledger.utxo.e2etest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_FAILED
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -79,7 +79,7 @@ class ChainableTests {
 
     @Test
     fun `chainable contract create command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -87,14 +87,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `chainable contract create command CONTRACT_RULE_CREATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -102,14 +102,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On chainable state(s) creating, at least one chainable state must be created.")
     }
 
     @Test
     fun `chainable contract create command CONTRACT_RULE_CREATE_POINTERS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -117,14 +117,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On chainable state(s) creating, the previous state pointer of every created chainable state must be null.")
     }
 
     @Test
     fun `chainable contract update command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -132,14 +132,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `chainable contract update command CONTRACT_RULE_UPDATE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -147,14 +147,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On chainable state(s) updating, at least one chainable state must be consumed.")
     }
 
     @Test
     fun `chainable contract update command CONTRACT_RULE_UPDATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -162,14 +162,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On chainable state(s) updating, at least one chainable state must be created.")
     }
 
     @Test
     fun `chainable contract update command CONTRACT_RULE_UPDATE_POINTERS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -177,15 +177,15 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On chainable state(s) updating, the previous state pointer of every created chainable state must not be null.")
     }
 
     @Test
     fun `chainable contract update command CONTRACT_RULE_UPDATE_EXCLUSIVE_POINTERS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -193,8 +193,8 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On chainable state(s) updating, the previous state pointer of every created chainable state must be pointing to exactly " +
@@ -204,7 +204,7 @@ class ChainableTests {
 
     @Test
     fun `chainable contract delete command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -212,14 +212,14 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `chainable contract delete command CONTRACT_RULE_DELETE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -227,8 +227,8 @@ class ChainableTests {
             ),
             "com.r3.corda.test.utxo.chainable.workflow.ChainableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On chainable state(s) deleting, at least one chainable state must be consumed.")
     }
 }

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/FungibleTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/FungibleTests.kt
@@ -75,7 +75,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract create command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -83,14 +83,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `fungible contract create command CONTRACT_RULE_CREATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -98,14 +98,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On fungible state(s) creating, at least one fungible state must be created.")
     }
 
     @Test
     fun `fungible contract create command CONTRACT_RULE_CREATE_POSITIVE_QUANTITIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -113,8 +113,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains(
             "On fungible state(s) creating, the quantity of every created fungible state must be greater than zero."
         )
@@ -122,7 +122,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract update command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -130,14 +130,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `fungible contract update command CONTRACT_RULE_UPDATE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -145,14 +145,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On fungible state(s) updating, at least one fungible state must be consumed.")
     }
 
     @Test
     fun `fungible contract update command CONTRACT_RULE_UPDATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -160,14 +160,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On fungible state(s) updating, at least one fungible state must be created.")
     }
 
     @Test
     fun `fungible contract update command CONTRACT_RULE_UPDATE_POSITIVE_QUANTITIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -175,15 +175,15 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On fungible state(s) updating, the quantity of every created fungible state must be greater than zero.")
     }
 
     @Test
     fun `fungible contract update command CONTRACT_RULE_UPDATE_SUM fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -191,8 +191,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On fungible state(s) updating, the sum of the unscaled values of the consumed states must be equal to the sum of the " +
@@ -202,7 +202,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract update command CONTRACT_RULE_UPDATE_GROUP_SUM fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -210,8 +210,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On fungible state(s) updating, the sum of the consumed states that are fungible with each other must be equal to the " +
@@ -221,7 +221,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract delete command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -229,14 +229,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `fungible contract delete command CONTRACT_RULE_DELETE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -244,14 +244,14 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains("On fungible state(s) deleting, at least one fungible state input must be consumed.")
     }
 
     @Test
     fun `fungible contract delete command CONTRACT_RULE_DELETE_POSITIVE_QUANTITIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -259,8 +259,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message).contains(
             "On fungible state(s) deleting, the quantity of every created fungible state must be greater than zero."
         )
@@ -268,7 +268,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract delete command CONTRACT_RULE_DELETE_SUM fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -276,8 +276,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On fungible state(s) deleting, the sum of the unscaled values of the consumed states must be greater than the sum of " +
@@ -287,7 +287,7 @@ class FungibleTests {
 
     @Test
     fun `fungible contract delete command CONTRACT_RULE_DELETE_GROUP_SUM fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -295,8 +295,8 @@ class FungibleTests {
             ),
             "com.r3.corda.test.utxo.fungible.workflow.FungibleContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On fungible state(s) deleting, the sum of consumed states that are fungible with each other must be greater than the " +

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IdentifiableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IdentifiableTests.kt
@@ -2,16 +2,16 @@ package com.r3.corda.ledger.utxo.e2etest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_FAILED
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
@@ -75,13 +75,13 @@ class IdentifiableTests {
     @Test
     fun `query identifiable states`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableStateQueryFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -102,13 +102,13 @@ class IdentifiableTests {
     @Test
     fun `identifiable pointer resolution`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiablePointerFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -128,7 +128,7 @@ class IdentifiableTests {
 
     @Test
     fun `Identifiable contract create command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -136,14 +136,14 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Identifiable contract create command CONTRACT_RULE_CREATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -151,15 +151,15 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On identifiable state(s) creating, at least one identifiable state must be created.")
     }
 
     @Test
     fun `Identifiable contract update command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -167,14 +167,14 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Identifiable contract update command CONTRACT_RULE_UPDATE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -182,15 +182,15 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On identifiable state(s) updating, at least one identifiable state must be consumed.")
     }
 
     @Test
     fun `Identifiable contract update command CONTRACT_RULE_UPDATE_OUTPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -198,15 +198,15 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On identifiable state(s) updating, at least one identifiable state must be created.")
     }
 
     @Test
     fun `Identifiable contract update command CONTRACT_RULE_UPDATE_IDENTIFIER_EXCLUSIVITY fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -214,12 +214,11 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
-                "On identifiable state(s) updating, each created identifiable state's identifier must match one consumed identifiable " +
-                        "state's state ref or identifier, exclusively."
+                "On identifiable state(s) updating, every created identifiable state's identifier must appear only once when the identifier is not null."
             )
     }
 
@@ -227,7 +226,7 @@ class IdentifiableTests {
     @Test
     @Disabled
     fun `Identifiable contract update command CONTRACT_RULE_UPDATE_IDENTIFIER_EXCLUSIVITY MISSING_ID fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -235,8 +234,8 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains(
                 "On identifiable state(s) updating, each created identifiable state's identifier must match one consumed identifiable " +
@@ -246,7 +245,7 @@ class IdentifiableTests {
 
     @Test
     fun `Identifiable contract delete command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -254,14 +253,14 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Identifiable contract delete command CONTRACT_RULE_DELETE_INPUTS fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -269,8 +268,8 @@ class IdentifiableTests {
             ),
             "com.r3.corda.test.utxo.identifiable.workflow.IdentifiableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On identifiable state(s) deleting, at least one identifiable state must be consumed.")
     }

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IssuableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/IssuableTests.kt
@@ -2,16 +2,16 @@ package com.r3.corda.ledger.utxo.e2etest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_FAILED
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -74,13 +74,13 @@ class IssuableTests {
     @Test
     fun `query issuable states`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.issuable.workflow.IssuableStateQueryFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -94,13 +94,13 @@ class IssuableTests {
     @Test
     fun `query well known issuable states`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.issuable.workflow.WellKnownIssuableStateQueryFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -113,7 +113,7 @@ class IssuableTests {
 
     @Test
     fun `Issuable contract create command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -122,14 +122,14 @@ class IssuableTests {
             ),
             "com.r3.corda.test.utxo.issuable.workflow.IssuableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Issuable contract create command CONTRACT_RULE_CREATE_SIGNATORIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "CREATE",
@@ -138,15 +138,15 @@ class IssuableTests {
             ),
             "com.r3.corda.test.utxo.issuable.workflow.IssuableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On issuable state(s) creating, the issuer of every created issuable state must sign the transaction.")
     }
 
     @Test
     fun `Issuable contract delete command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -155,14 +155,14 @@ class IssuableTests {
             ),
             "com.r3.corda.test.utxo.issuable.workflow.IssuableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Issuable contract delete command CONTRACT_RULE_DELETE_SIGNATORIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "DELETE",
@@ -171,8 +171,8 @@ class IssuableTests {
             ),
             "com.r3.corda.test.utxo.issuable.workflow.IssuableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On issuable state(s) deleting, the issuer of every consumed issuable state must sign the transaction.")
     }

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/OwnableTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/OwnableTests.kt
@@ -2,16 +2,16 @@ package com.r3.corda.ledger.utxo.e2etest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_FAILED
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -74,13 +74,13 @@ class OwnableTests {
     @Test
     fun `query ownable states`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.ownable.workflow.OwnableStateQueryFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -94,13 +94,13 @@ class OwnableTests {
     @Test
     fun `query well known ownable states`() {
 
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.test.utxo.ownable.workflow.WellKnownOwnableStateQueryFlow"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val response = objectMapper
@@ -113,7 +113,7 @@ class OwnableTests {
 
     @Test
     fun `Ownable contract update command valid`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -122,14 +122,14 @@ class OwnableTests {
             ),
             "com.r3.corda.test.utxo.ownable.workflow.OwnableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(response.flowError).isNull()
     }
 
     @Test
     fun `Ownable contract update command CONTRACT_RULE_UPDATE_SIGNATORIES fails`() {
-        val request = startRpcFlow(
+        val request = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "command" to "UPDATE",
@@ -138,8 +138,8 @@ class OwnableTests {
             ),
             "com.r3.corda.test.utxo.ownable.workflow.OwnableContractTestFlow"
         )
-        val response = awaitRpcFlowFinished(aliceHoldingId, request)
-        assertThat(response.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+        val response = awaitRestFlowFinished(aliceHoldingId, request)
+        assertThat(response.flowStatus).isEqualTo(REST_FLOW_STATUS_FAILED)
         assertThat(response.flowError?.message)
             .contains("On ownable state(s) updating, the owner of every consumed ownable state must sign the transaction.")
     }

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/ChainableDemoTests.kt
@@ -3,15 +3,15 @@ package com.r3.corda.ledger.utxo.e2etest.demo
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.r3.corda.ledger.utxo.e2etest.uploadTrustedCertificate
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -83,7 +83,7 @@ class ChainableDemoTests {
         // Alice issues vehicle to Bob
         val vehicleId = UUID.randomUUID()
 
-        val issueVehicleFlowRequestId = startRpcFlow(
+        val issueVehicleFlowRequestId = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "make" to "reliant",
@@ -96,8 +96,8 @@ class ChainableDemoTests {
             ),
             "com.r3.corda.demo.utxo.chainable.workflow.issue.IssueVehicleFlow\$Initiator"
         )
-        val issueVehicleFlowResult = awaitRpcFlowFinished(aliceHoldingId, issueVehicleFlowRequestId)
-        assertThat(issueVehicleFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val issueVehicleFlowResult = awaitRestFlowFinished(aliceHoldingId, issueVehicleFlowRequestId)
+        assertThat(issueVehicleFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(issueVehicleFlowResult.flowError).isNull()
 
         val issuedVehicleResponse = objectMapper
@@ -110,7 +110,7 @@ class ChainableDemoTests {
         assertThat(issuedVehicleResponse.owner).isEqualTo(bobX500)
 
         // Bob transfers vehicle to Charlie
-        val transferVehicleRequestId = startRpcFlow(
+        val transferVehicleRequestId = startRestFlow(
             bobHoldingId,
             mapOf(
                 "id" to vehicleId,
@@ -119,8 +119,8 @@ class ChainableDemoTests {
             ),
             "com.r3.corda.demo.utxo.chainable.workflow.transfer.TransferVehicleFlow\$Initiator"
         )
-        val transferVehicleFlowResult = awaitRpcFlowFinished(bobHoldingId, transferVehicleRequestId)
-        assertThat(transferVehicleFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val transferVehicleFlowResult = awaitRestFlowFinished(bobHoldingId, transferVehicleRequestId)
+        assertThat(transferVehicleFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(transferVehicleFlowResult.flowError).isNull()
 
         val transferVehicleResponse = objectMapper

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/FungibleDemoTests.kt
@@ -78,7 +78,7 @@ class FungibleDemoTests {
     fun `Alice issues a token to Bob, Bob then transfers to Charlie, and then Bob burns some quantity of their token`() {
 
         // Alice issues tokens to Bob
-        val mintTokenFlowRequestId = startRpcFlow(
+        val mintTokenFlowRequestId = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "issuer" to aliceX500,
@@ -89,8 +89,8 @@ class FungibleDemoTests {
             ),
             "com.r3.corda.demo.utxo.fungible.workflow.mint.MintTokenFlow\$Initiator"
         )
-        val mintTokenFlowResult = awaitRpcFlowFinished(aliceHoldingId, mintTokenFlowRequestId)
-        assertThat(mintTokenFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val mintTokenFlowResult = awaitRestFlowFinished(aliceHoldingId, mintTokenFlowRequestId)
+        assertThat(mintTokenFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(mintTokenFlowResult.flowError).isNull()
 
         val mintTokenResponse = objectMapper.readValue(mintTokenFlowResult.flowResult, MintTokenResponse::class.java)
@@ -105,7 +105,7 @@ class FungibleDemoTests {
         assertThat(quantity).isEqualTo(123.45.toScaledBigDecimal())
 
         // Bob transfers tokens to Charlie and receives change
-        val moveTokenFlowRequestId = startRpcFlow(
+        val moveTokenFlowRequestId = startRestFlow(
             bobHoldingId,
             mapOf(
                 "issuer" to aliceX500,
@@ -117,8 +117,8 @@ class FungibleDemoTests {
             ),
             "com.r3.corda.demo.utxo.fungible.workflow.move.MoveTokenFlow\$Initiator"
         )
-        val moveTokenFlowResult = awaitRpcFlowFinished(bobHoldingId, moveTokenFlowRequestId)
-        assertThat(moveTokenFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val moveTokenFlowResult = awaitRestFlowFinished(bobHoldingId, moveTokenFlowRequestId)
+        assertThat(moveTokenFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(moveTokenFlowResult.flowError).isNull()
 
         val moveTokenResponse = objectMapper.readValue(moveTokenFlowResult.flowResult, MoveTokenResponse::class.java)
@@ -133,7 +133,7 @@ class FungibleDemoTests {
         )
 
         // Bob redeems tokens
-        val burnTokenFlowRequestId = startRpcFlow(
+        val burnTokenFlowRequestId = startRestFlow(
             bobHoldingId,
             mapOf(
                 "issuer" to aliceX500,
@@ -144,8 +144,8 @@ class FungibleDemoTests {
             "com.r3.corda.demo.utxo.fungible.workflow.burn.BurnTokenFlow\$Initiator"
         )
 
-        val burnTokenFlowResult = awaitRpcFlowFinished(bobHoldingId, burnTokenFlowRequestId)
-        assertThat(burnTokenFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val burnTokenFlowResult = awaitRestFlowFinished(bobHoldingId, burnTokenFlowRequestId)
+        assertThat(burnTokenFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(burnTokenFlowResult.flowError).isNull()
 
         val burnTokenResponse = objectMapper.readValue(burnTokenFlowResult.flowResult, BurnTokenResponse::class.java)

--- a/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
+++ b/e2e-tests/src/e2eTest/kotlin/com/r3/corda/ledger/utxo/e2etest/demo/IdentifiableDemoTests.kt
@@ -3,15 +3,15 @@ package com.r3.corda.ledger.utxo.e2etest.demo
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.r3.corda.ledger.utxo.e2etest.uploadTrustedCertificate
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -74,7 +74,7 @@ class IdentifiableDemoTests {
     @Test
     fun `Alice issues a support ticket to Bob, Bob opens and completes the ticket, Alice closes the ticket`() {
 
-        val issueSupportTicketRequestId = startRpcFlow(
+        val issueSupportTicketRequestId = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "title" to "Build Corda 5",
@@ -86,14 +86,14 @@ class IdentifiableDemoTests {
             ),
             "com.r3.corda.demo.utxo.identifiable.workflow.create.CreateSupportTicketFlow\$Initiator"
         )
-        val createFlowResponse = awaitRpcFlowFinished(aliceHoldingId, issueSupportTicketRequestId)
-        assertThat(createFlowResponse.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val createFlowResponse = awaitRestFlowFinished(aliceHoldingId, issueSupportTicketRequestId)
+        assertThat(createFlowResponse.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(createFlowResponse.flowError).isNull()
 
         val createSupportTicketResponse = objectMapper
             .readValue(createFlowResponse.flowResult, CreateSupportTicketResponse::class.java)
 
-        val openSupportTicketRequestId = startRpcFlow(
+        val openSupportTicketRequestId = startRestFlow(
             bobHoldingId,
             mapOf(
                 "id" to createSupportTicketResponse.id,
@@ -103,8 +103,8 @@ class IdentifiableDemoTests {
             ),
             "com.r3.corda.demo.utxo.identifiable.workflow.update.UpdateSupportTicketFlow\$Initiator"
         )
-        val openFlowResult = awaitRpcFlowFinished(bobHoldingId, openSupportTicketRequestId)
-        assertThat(openFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val openFlowResult = awaitRestFlowFinished(bobHoldingId, openSupportTicketRequestId)
+        assertThat(openFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(openFlowResult.flowError).isNull()
 
         val openSupportTicketResponse = objectMapper
@@ -113,7 +113,7 @@ class IdentifiableDemoTests {
         assertThat(openSupportTicketResponse.id).isEqualTo(createSupportTicketResponse.id)
         assertThat(openSupportTicketResponse.title).isEqualTo(createSupportTicketResponse.title)
 
-        val doneSupportTicketRequestId = startRpcFlow(
+        val doneSupportTicketRequestId = startRestFlow(
             bobHoldingId,
             mapOf(
                 "id" to openSupportTicketResponse.id,
@@ -123,8 +123,8 @@ class IdentifiableDemoTests {
             ),
             "com.r3.corda.demo.utxo.identifiable.workflow.update.UpdateSupportTicketFlow\$Initiator"
         )
-        val doneFlowResult = awaitRpcFlowFinished(bobHoldingId, doneSupportTicketRequestId)
-        assertThat(doneFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val doneFlowResult = awaitRestFlowFinished(bobHoldingId, doneSupportTicketRequestId)
+        assertThat(doneFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(doneFlowResult.flowError).isNull()
 
         val doneSupportTicketResponse = objectMapper
@@ -133,7 +133,7 @@ class IdentifiableDemoTests {
         assertThat(doneSupportTicketResponse.id).isEqualTo(openSupportTicketResponse.id)
         assertThat(doneSupportTicketResponse.title).isEqualTo(openSupportTicketResponse.title)
 
-        val deleteSupportTicketRequestId = startRpcFlow(
+        val deleteSupportTicketRequestId = startRestFlow(
             aliceHoldingId,
             mapOf(
                 "id" to doneSupportTicketResponse.id,
@@ -143,8 +143,8 @@ class IdentifiableDemoTests {
             "com.r3.corda.demo.utxo.identifiable.workflow.delete.DeleteSupportTicketFlow\$Initiator"
         )
 
-        val deleteSupportTicketResult = awaitRpcFlowFinished(aliceHoldingId, deleteSupportTicketRequestId)
-        assertThat(deleteSupportTicketResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val deleteSupportTicketResult = awaitRestFlowFinished(aliceHoldingId, deleteSupportTicketRequestId)
+        assertThat(deleteSupportTicketResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(deleteSupportTicketResult.flowError).isNull()
 
         val deleteSupportTicketResponse = objectMapper

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,14 +6,14 @@ kotlin.code.style=official
 
 # Specify the version of the Corda-API to use.
 # This needs to match the version supported by the Corda Cluster the CorDapp will run on.
-cordaApiVersion=5.1.0.39
+cordaApiVersion=5.2.0.49-beta+
 
 
 # E2e test utilities should come from runtime-os
-cordaRuntimeOsVersion=5.1.0.0-beta+
+cordaRuntimeOsVersion=5.2.0.0-beta+
 
 # Specify the version of the notary plugins to use, if left blank this will default to value of cordaRuntimeOsVersion
-cordaNotaryPluginsVersion=5.0.0.0-beta+
+cordaNotaryPluginsVersion=5.2.0.0-beta+
 
 # Specify the version of the cordapp-cpb2 and cordapp-cpk2 plugins
 cordaPluginsVersion=7.0.3

--- a/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiableContractUpdateCommand.java
+++ b/identifiable/src/main/java/com/r3/corda/ledger/utxo/identifiable/IdentifiableContractUpdateCommand.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
  *     <li>On identifiable state(s) updating, at least one identifiable state must be consumed.</li>
  *     <li>On identifiable state(s) updating, at least one identifiable state must be created.</li>
  *     <li>On identifiable state(s) updating, each created identifiable state's identifier must match one consumed identifiable state's state ref or identifier, exclusively.</li>
+ *     <li>On identifiable state(s) updating, only one identifiable state with a matching identifier must be consumed for every created identifiable state with a non-null identifier.</li>
+ *     <li>On identifiable state(s) updating, every created identifiable state's identifier must appear only once when the identifier is not null.</li>
  * </ol>
  */
 public abstract class IdentifiableContractUpdateCommand<T extends IdentifiableState> extends IdentifiableContractCommand<T> {

--- a/identifiable/src/test/kotlin/com/r3/corda/ledger/utxo/identifiable/ExampleIdentifiableContractUpdateCommandTests.kt
+++ b/identifiable/src/test/kotlin/com/r3/corda/ledger/utxo/identifiable/ExampleIdentifiableContractUpdateCommandTests.kt
@@ -80,7 +80,24 @@ class ExampleIdentifiableContractUpdateCommandTests : ContractTest() {
     }
 
     @Test
-    fun `On identifiable state(s) updating, each created identifiable state's identifier must match one consumed identifiable state's state ref or identifier, exclusively (initial state)`() {
+    fun `On identifiable state(s) updating, only one identifiable state with a matching identifier must be consumed for every created identifiable state with a non-null identifier`() {
+
+        // Arrange
+        val transaction = buildTransaction(NOTARY_KEY, NOTARY_NAME) {
+            addInputState(state)
+            addOutputState(state.copy(id = randomStateRef()))
+            addCommand(ExampleIdentifiableContract.Update())
+        }
+
+        // Act
+        val exception = assertThrows<IllegalStateException> { contract.verify(transaction) }
+
+        // Assert
+        assertEquals(IdentifiableConstraints.CONTRACT_RULE_UPDATE_IDENTIFIERS, exception.message)
+    }
+
+    @Test
+    fun `On identifiable state(s) updating, every created identifiable state's identifier must appear only once when the identifier is not null (initial state)`() {
         // Arrange
         val transaction = buildTransaction(NOTARY_KEY, NOTARY_NAME) {
             val stateRef1 = randomStateRef()
@@ -98,7 +115,7 @@ class ExampleIdentifiableContractUpdateCommandTests : ContractTest() {
     }
 
     @Test
-    fun `On identifiable state(s) updating, each created identifiable state's identifier must match one consumed identifiable state's state ref or identifier, exclusively (evolved state)`() {
+    fun `On identifiable state(s) updating, every created identifiable state's identifier must appear only once when the identifier is not null (evolved state)`() {
         // Arrange
         val transaction = buildTransaction(NOTARY_KEY, NOTARY_NAME) {
             val stateRef1 = randomStateRef()


### PR DESCRIPTION
### Overview

- Fix bug identifiable state contract constraints allowing multiple outputs with the same ID
- Update API/runtime-os/notary plugin version to 5.2
- Fix compilation of e2e tests to align with 5.2
- Fix e2e test for the bugfix