### PR TITLE
ES-1805 Update version to be 1.0.0 in line with current branch name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.2') _
 
 cordaPipelineKubernetesAgent(
     publishRepoPrefix: 'corda-os-maven',
@@ -9,6 +9,6 @@ cordaPipelineKubernetesAgent(
     e2eTestName: 'corda-utxo-ledger-extensions-e2e-tests',
     runE2eTests: true,
     publishToMavenS3Repository: true,
-    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.1.0.0-beta+',
+    gradleAdditionalArgs: '-PcordaNotaryPluginsVersion=5.2.0.0-beta+',
     javaVersion: '17'
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.java.installations.auto-download=false
 
-cordautxoVersion=0.9.0
+cordautxoVersion=1.0.0
 kotlin.code.style=official
 
 # Specify the version of the Corda-API to use.


### PR DESCRIPTION
- `0.9.0` was associated with a previous branch now dead, the version should be updated to match the current branch `release/os/1.0` , as such moving version to `1.0.0`

- Minor adjustments to Jenkins file where config values were outdated referencing 5.1